### PR TITLE
Corrected Title of Medium Icon

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -16,7 +16,7 @@
       </a>
       {% endif %}
       {% if site.medium_username %}
-      <a itemprop="medium" href="https://medium.com/@{{ site.medium_username }}" title="Twitter">
+      <a itemprop="medium" href="https://medium.com/@{{ site.medium_username }}" title="Medium">
         <svg><use xlink:href="#icon-medium"></use></svg>
       </a>
       {% endif %}


### PR DESCRIPTION
The title on hovering the Medium Icon was showing Twitter instead of medium. I've updated it!