### PR TITLE
Add math feature

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -103,7 +103,18 @@
         {% if author.linkedin_username %}
             {% assign author_urls = author_urls | append: '"https://www.linkedin.com/in/' | append: author.linkedin_username | append: '",' %}
         {% endif %}
-
+        {% if page.math %}
+        <script>
+            MathJax = {
+                tex: {
+                inlineMath: [['$', '$'], ['\\(', '\\)']]
+                }
+            };
+        </script>
+        <script type="text/javascript" id="MathJax-script" async
+            src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js">
+        </script>
+        {% endif %}
         <script type="application/ld+json">
         {
             "@context": "http://schema.org",

--- a/_posts/2020-03-21-mathjax-support.md
+++ b/_posts/2020-03-21-mathjax-support.md
@@ -1,0 +1,23 @@
+---
+date: 2020-03-21 13:13:38
+layout: post
+title: "mathjax support"
+subtitle:
+description:
+image:
+optimized_image:
+category:
+tags:
+author:
+paginate: false
+math: true
+---
+
+Here is a new feature to use math formula with _Jekflix Template_ using _MathJax_. You only need 2 steps:
+
+1. Set `math: true` for a post.
+2. Adopt the _MathJax_'s grammar for $\LaTeX$.
+
+For example, `$\sum_{i=1}{10} = 55$` will be rendered as $\sum_{i=1}{10} = 55$.
+
+Reference for [_MathJax_](http://docs.mathjax.org/en/latest/index.html).


### PR DESCRIPTION
I add the math feature by including _MathJax_. 
To enable math formula, one only need to set  math: true in a post.
It should be very convenient for those who need to include math formula using the template!