### PR TITLE
Last comma logic in json+ld

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -178,7 +178,7 @@ layout: main
                 "genre": "{{ post.category | capitalize }}",
 		        "articleSection": "{{ post.category | capitalize }}",
                 "keywords": [{{ post.tags | join: '","' | append: '"' | prepend: '"' }}]
-            }{% if forloop.index < limit %},{% endif %}
+            }{% if forloop.last == false  %},{% endif %}
         {% endfor %}
         ]
     }


### PR DESCRIPTION
An updated way of adding commas in a list of json+ld of the home page layout.

Actually, I encountered this only when I publish my website with only two posts and submitted it to Google webmaster.

Logic is fine having said that if you publish with a minimum of 8 posts.

`{% assign limit = 8 %}
{% for post in posts limit: limit %}
{% endfor %}
`