### PR TITLE
Twiter:card check if image url is absolute or relative (to add baseurl)

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -43,7 +43,13 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="{{ title }}">
     <meta name="twitter:description" content="{{ description }}">
-    <meta property="twitter:image:src" content="{{ image }}">
+
+    {% if image contains '://' %}
+        <meta property="twitter:image" content="{{ image }}">
+    {% else %}
+        <meta property="twitter:image" content="{{ image | prepend: site.url }}">
+    {% endif %}
+    
     {% if site.twitter_username %}
         <meta name="twitter:site" content="@{{ site.twitter_username }}">
     {% endif %}


### PR DESCRIPTION
When using relative images in posts (p.e `/assets/img/uploads/whatever.jpg`) the twitter sharing link, fails to show the image.

The change check if the url is relative and add the base url in that case